### PR TITLE
Added Turret config inclusion

### DIFF
--- a/doc/first_project.rst
+++ b/doc/first_project.rst
@@ -86,7 +86,7 @@ Every key here is useful, but some keys are not required to run a test. Let's ta
 
 * ``min_turrets``: The minimum number of turrets that must be deployed before the HQ sends the start message
 
-* ``turrets``: a list of turrets, this key will be use to package turrets with the `oct pack-turrets` command
+* ``turrets``: a list of turrets, this key will be use to package turrets with the `oct pack-turrets` command. Instead of a JSON it can be a string representing a path to a turret configuration file.
 
 * ``turrets_requirements``: A list of string containing the required packages for turrets (only for python turrets at this time)
 

--- a/oct/utilities/configuration.py
+++ b/oct/utilities/configuration.py
@@ -1,5 +1,6 @@
 import os
 import json
+import six
 
 from oct.core.exceptions import OctConfigurationError
 
@@ -42,6 +43,16 @@ def configure(project_path, config_file=None):
     return config
 
 
+def load_turret_config(project_path, config_file):
+    config_file = os.path.join(project_path, config_file)
+    try:
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+    except (ValueError, IOError) as e:
+        raise OctConfigurationError("Turret configuration %s failed: %s" % (config_file, e))
+    return config
+
+
 def configure_for_turret(project_name, config_file):
     """Load the configuration file in python dict and check for keys that will be set to default value if not present
 
@@ -62,6 +73,8 @@ def configure_for_turret(project_name, config_file):
     }
     configs = []
     for turret in config['turrets']:
+        if isinstance(turret, six.string_types):
+            turret = load_turret_config(project_name, turret)
         turret.update(common_config)
         turret.update(config.get('extra_turret_config', {}))
         configs.append(turret)


### PR DESCRIPTION
This patch allows to specify turrets as a path. The list `turrets` can now contain a simple string representing a configuration file to import. (relative to oct project)