### PR TITLE
Added setup/teardown and dynamic HQ class

### DIFF
--- a/oct/core/hq.py
+++ b/oct/core/hq.py
@@ -3,10 +3,22 @@ import zmq
 import time
 import ujson
 import traceback
+import importlib
 from zmq.utils.strtypes import asbytes
 
 from oct.core.turrets_manager import TurretsManager
 from oct.results.stats_handler import StatsHandler
+
+DEFAULT_HIGHTQUATER_CLASS = 'oct.core.hq.HightQuarter'
+
+
+def get_hq_class(path=None):
+    path = path or DEFAULT_HIGHTQUATER_CLASS
+    module_path = '.'.join(path.split('.')[:-1])
+    object_name = path.split('.')[-1]
+    module = importlib.import_module(module_path)
+    hq_class = getattr(module, object_name)
+    return hq_class
 
 
 class HightQuarter(object):
@@ -147,3 +159,13 @@ class HightQuarter(object):
         self.result_collector.unbind(self.result_collector.LAST_ENDPOINT)
         self._clean_queue()
         print("took %s" % (time.time() - t))
+
+    def setup(self):
+        """This method will be called before to start turrets.
+        """
+        pass
+
+    def tear_down(self):
+        """This method will be called after to stop turrets.
+        """
+        pass

--- a/oct/utilities/run.py
+++ b/oct/utilities/run.py
@@ -8,7 +8,7 @@ from oct.results.output import output as output_results
 
 import oct.results.stats_handler as stats_handler
 from oct.utilities.configuration import configure
-from oct.core.hq import HightQuarter
+from oct.core.hq import get_hq_class
 
 
 def process_results(output_dir, config):
@@ -33,10 +33,13 @@ def copy_config(project_path, output_dir):
 def start_hq(output_dir, config, topic, is_master=True, **kwargs):
     """Start a HQ
     """
+    HightQuarter = get_hq_class(config.get('hq_class'))
     hq = HightQuarter(output_dir, config, topic, **kwargs)
+    hq.setup()
     if is_master:
         hq.wait_turrets(config.get("min_turrets", 1))
     hq.run()
+    hq.tear_down()
 
 
 def generate_output_path(args, project_path):

--- a/tests/test_hq.py
+++ b/tests/test_hq.py
@@ -6,6 +6,7 @@ import json
 from multiprocessing import Process
 from oct_turrets.turret import Turret
 from oct_turrets.utils import load_file, validate_conf
+from oct.core.hq import get_hq_class, HightQuarter
 from oct.utilities.run import run
 from oct.utilities.commands import main
 
@@ -83,6 +84,14 @@ class HQTest(unittest.TestCase):
         self.bad_turret.terminate()
         if os.path.isfile('/tmp/results.sqlite'):
             os.remove('/tmp/results.sqlite')
+
+
+class GetHqClassTest(unittest.TestCase):
+    def test_get_hq_class(self):
+        hq_class = get_hq_class()
+        self.assertEqual(hq_class, HightQuarter)
+        hq_class = get_hq_class('oct.core.hq.HightQuarter')
+        self.assertEqual(hq_class, HightQuarter)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I really would like to be able to set up a part of my environment and destroy it a the end.
I imagine to spawn a HTTP server in `setup` and remove it in `tear_down`.

Next step could be to transfer data to turrets at setup: The VM's IP for example.
What do you think about ?