### PR TITLE
Added Transaction context passing to turrets

### DIFF
--- a/oct/core/hq.py
+++ b/oct/core/hq.py
@@ -44,6 +44,7 @@ class HightQuarter(object):
         self.stats_handler = StatsHandler(config.get('results_database', {}).get('insert_limit', 150))
 
         self._configure_sockets(config)
+        self.transaction_context = {}
         self.turrets_manager = TurretsManager(config.get('publish_port', 5000), master)
         self.config = config
         self.started = False
@@ -138,7 +139,7 @@ class HightQuarter(object):
         run_time = self.config['run_time']
         start_time = time.time()
         t = time.time
-        self.turrets_manager.start()
+        self.turrets_manager.start(self.transaction_context)
         self.started = True
 
         while elapsed <= run_time:

--- a/oct/core/hq.py
+++ b/oct/core/hq.py
@@ -3,10 +3,22 @@ import zmq
 import time
 import ujson
 import traceback
+import importlib
 from zmq.utils.strtypes import asbytes
 
 from oct.core.turrets_manager import TurretsManager
 from oct.results.stats_handler import StatsHandler
+
+DEFAULT_HIGHTQUATER_CLASS = 'oct.core.hq.HightQuarter'
+
+
+def get_hq_class(path=None):
+    path = path or DEFAULT_HIGHTQUATER_CLASS
+    module_path = '.'.join(path.split('.')[:-1])
+    object_name = path.split('.')[-1]
+    module = importlib.import_module(module_path)
+    hq_class = getattr(module, object_name)
+    return hq_class
 
 
 class HightQuarter(object):
@@ -147,3 +159,13 @@ class HightQuarter(object):
         self.result_collector.unbind(self.result_collector.LAST_ENDPOINT)
         self._clean_queue()
         print("took %s" % (time.time() - t))
+
+    def setup(self):
+        """This method will be called before to start turrets.
+        """
+        pass
+
+    def tear_down(self):
+        """This method will be called after to stop turrets.
+        """
+        pass

--- a/oct/core/turrets_manager.py
+++ b/oct/core/turrets_manager.py
@@ -29,9 +29,13 @@ class TurretsManager(object):
     def clean(self):
         self.publisher.close()
 
-    def start(self):
+    def start(self, transaction_context=None):
         """Publish start message to all turrets
         """
+        transaction_context = transaction_context or {}
+        context_cmd = {'command': 'set_transaction_context',
+                       'msg': transaction_context}
+        self.publish(context_cmd)
         self.publish(self.START)
 
     def stop(self):

--- a/oct/utilities/run.py
+++ b/oct/utilities/run.py
@@ -8,7 +8,7 @@ from oct.results.output import output as output_results
 
 import oct.results.stats_handler as stats_handler
 from oct.utilities.configuration import configure
-from oct.core.hq import HightQuarter
+from oct.core.hq import get_hq_class
 
 
 def process_results(output_dir, config):
@@ -33,10 +33,13 @@ def copy_config(project_path, output_dir):
 def start_hq(output_dir, config, topic, is_master=True, **kwargs):
     """Start a HQ
     """
+    HightQuarter = get_hq_class(config.get('hq_class'))
     hq = HightQuarter(output_dir, config, topic, **kwargs)
+    hq.setup()
     if is_master:
         hq.wait_turrets(config.get("min_turrets", 1))
     hq.run()
+    hq.tear_down()
 
 
 def generate_output_path(args, project_path):

--- a/tests/test_hq.py
+++ b/tests/test_hq.py
@@ -6,6 +6,7 @@ import json
 from multiprocessing import Process
 from oct_turrets.turret import Turret
 from oct_turrets.utils import load_file, validate_conf
+from oct.core.hq import get_hq_class, HightQuarter
 from oct.utilities.run import run
 from oct.utilities.commands import main
 
@@ -83,6 +84,14 @@ class HQTest(unittest.TestCase):
         self.bad_turret.terminate()
         if os.path.isfile('/tmp/results.sqlite'):
             os.remove('/tmp/results.sqlite')
+
+
+class GetHqClassTest(unittest.TestCase):
+    def test_get_hq_class(self):
+        hq_class = get_hq_class()
+        self.assertEqual(hq_class, HightQuarter)
+        hq_class = get_hq_class('oct.core.hq.HightQuarter')
+        self.assertEqual(hq_class, HightQuarter)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR comes after #51 and with https://github.com/TheGhouls/oct-turrets/pull/14

As said in PR 14,
It helps to create something from HQ and give dynamic data to turrets.

With this set of patch, we could imagine the following scenario:
1. A HQ in its `setup` build things and keep it in its `self.transaction_context`
2. Before start each turret, it sends these data with ZMQ `set_transaction_context`
3. Turret receive and store in `self.transaction_context`
4. When start cannons, it pass it and cannons store in their `self.transaction_context`
5. Each transaction receive and store it in `self.context`
6. Transaction can use data from HQ in its `run`

From 4. codebase already can do it.

I think the name `transaction_context` could be innapropriate because this data will pass and can be modified at each step of OCT's mechanism. But at the end it is for transactions.