### PR TITLE
Added end of run when turret finished

### DIFF
--- a/oct/core/hq.py
+++ b/oct/core/hq.py
@@ -134,6 +134,8 @@ class HightQuarter(object):
                 self._run_loop_action()
                 self._print_status(elapsed)
                 elapsed = t() - start_time
+                if self.turrets_manager.finished_count == self.config['min_turrets']:
+                    break
             except (Exception, KeyboardInterrupt):
                 print("\nStopping test, sending stop command to turrets")
                 self.turrets_manager.stop()

--- a/oct/core/turrets_manager.py
+++ b/oct/core/turrets_manager.py
@@ -20,6 +20,7 @@ class TurretsManager(object):
     def __init__(self, publish_port, master=True):
         self.turrets = {}
         self.master = master
+        self.finished_count = 0
 
         if master:
             context = zmq.Context()
@@ -89,6 +90,8 @@ class TurretsManager(object):
         turret = self.turrets[turret_data.get('uuid')]
         turret.update(**turret_data)
         self.write(turret)
+        if turret_data['status'] == 'finished':
+            self.finished_count += 1
         return True
 
     def write(self, turret):


### PR DESCRIPTION
This PR comes with https://github.com/TheGhouls/oct-turrets/pull/15

It helps to terminate run when all turrets has finished.

I avoid to use DB to count finished, to not make a conflict with V1 code.